### PR TITLE
Fix: Improve the user experience on list page

### DIFF
--- a/src/pages/feedbacks/ListPage/components/Sidebar/style.scss
+++ b/src/pages/feedbacks/ListPage/components/Sidebar/style.scss
@@ -38,6 +38,7 @@ $header-height: 72px;
     padding: 0 map.get($content-margin, "mobile");
     position: fixed;
     width: 100vw;
+    z-index: map.get($z-index, 'sticky');
     small {
       opacity: 0.75;
     }

--- a/src/pages/feedbacks/ListPage/style.scss
+++ b/src/pages/feedbacks/ListPage/style.scss
@@ -11,7 +11,7 @@
   }
   &__spinner {
     position: absolute;
-    left: 50vh;
+    left: 50%;
     top: 25vh;
     transform: translate(-50%, 0);
     z-index: 999;


### PR DESCRIPTION
1. Centralize the spiner on mobile screen for list page
2. Add z-index value to brand to make sure the list content doesn't jump over the sidebar header