### PR TITLE
Fix: redesign feedback query key to avoid refreshing feedback comment…

### DIFF
--- a/src/hooks/queries/feedbacks/queryKey.ts
+++ b/src/hooks/queries/feedbacks/queryKey.ts
@@ -7,15 +7,12 @@ export const getFeedbcksQueryKey = (query?: Record<string, string>) => {
 };
 
 export const getFeedbackQueryKey = (id: string) => {
-  const prefix = getFeedbcksQueryKey();
-
-  return [prefix, id];
+  return ['feedback', id, 'detail'];
 };
 
 export const getFeedbackCommentsQueryKey = (id: string) => {
-  const prefix = getFeedbackQueryKey(id);
 
-  return [...prefix, 'comments'];
+  return ['feedback', id, 'comments'];
 };
 
 export const getFeedbackStatsQueryKey = () => {


### PR DESCRIPTION
redesign query key for feedback detail page, to avoid refreshing comments in cache after voting a feedback